### PR TITLE
fix: Change select_content to select_item

### DIFF
--- a/src/main/java/com/mparticle/kits/GoogleAnalyticsFirebaseGA4Kit.java
+++ b/src/main/java/com/mparticle/kits/GoogleAnalyticsFirebaseGA4Kit.java
@@ -129,7 +129,7 @@ public class GoogleAnalyticsFirebaseGA4Kit extends KitIntegration implements Kit
                 eventName = FirebaseAnalytics.Event.REMOVE_FROM_CART;
                 break;
             case Product.CLICK:
-                eventName = FirebaseAnalytics.Event.SELECT_CONTENT;
+                eventName = FirebaseAnalytics.Event.SELECT_ITEM;
                 break;
             case Product.CHECKOUT_OPTION:
                 Map<String, List<String>> customFlags = commerceEvent.getCustomFlags();


### PR DESCRIPTION
# Summary

Per Google's [GA4 migration docs](https://support.google.com/analytics/answer/10119380?hl=en#) - `select_content` has been changed to `select_item`.

