### PR TITLE
fix: Change empty space to white space

### DIFF
--- a/src/main/java/com/mparticle/kits/GoogleAnalyticsFirebaseGA4Kit.java
+++ b/src/main/java/com/mparticle/kits/GoogleAnalyticsFirebaseGA4Kit.java
@@ -525,7 +525,7 @@ public class GoogleAnalyticsFirebaseGA4Kit extends KitIntegration implements Kit
         if (name == null) {
             return null;
         }
-        name = name.replaceAll("[^a-zA-Z0-9_\\s]", "");
+        name = name.replaceAll("[^a-zA-Z0-9_\\s]", " ");
         name = name.replaceAll("[\\s]+", "_");
 
         for(String forbiddenPrefix: forbiddenPrefixes) {


### PR DESCRIPTION
Fix empty space typo in standardizeName to white space

## Summary
- iOS and Android has different standardization behavior for Firebase integrations. This is caused by a typo in the Android kit where disallowed characters are replaced by empty space, when they should be replaced by space. This is for the GAv4 version of the Firebase kit.

## Testing Plan
- {explain how this has been tested, and what additional testing should be done}

## Reference Issue
- Closes https://mparticle-eng.atlassian.net/browse/PRODRDMP-4981
