### PR TITLE
fix: Change empty space typo to white space in standardizeName method

### DIFF
--- a/src/main/kotlin/com/mparticle/kits/GoogleAnalyticsFirebaseGA4Kit.kt
+++ b/src/main/kotlin/com/mparticle/kits/GoogleAnalyticsFirebaseGA4Kit.kt
@@ -550,7 +550,7 @@ class GoogleAnalyticsFirebaseGA4Kit : KitIntegration(), KitIntegration.EventList
 
         var name = nameIn ?: return null
 
-        name = name.replace("[^a-zA-Z0-9_\\s]".toRegex(), "")
+        name = name.replace("[^a-zA-Z0-9_\\s]".toRegex(), " ")
         name = name.replace("[\\s]+".toRegex(), "_")
         for (forbiddenPrefix in forbiddenPrefixes) {
             if (name.startsWith(forbiddenPrefix)) {


### PR DESCRIPTION
## Summary
- Change empty space typo to white space in standardizeName method.

## Testing Plan
- All test passed and events are being logged as needed.

## Reference Issue
- Closes https://go.mparticle.com/work/SQDSDKS-4389

