### PR TITLE
fix: Commerce event custom attributes are now being sent to GA4

### DIFF
--- a/src/main/kotlin/com/mparticle/kits/GoogleAnalyticsFirebaseGA4Kit.kt
+++ b/src/main/kotlin/com/mparticle/kits/GoogleAnalyticsFirebaseGA4Kit.kt
@@ -389,9 +389,18 @@ class GoogleAnalyticsFirebaseGA4Kit : KitIntegration(), KitIntegration.EventList
                 }
             }
         }
-        return pickyBundle
+
+        commerceEvent.customAttributes?.let { customAttributes ->
+            for (attributes in customAttributes) {
+                pickyBundle.putString(attributes.key, attributes.value.toString())
+            }
+        }
+
+        pickyBundle
             .putString(FirebaseAnalytics.Param.CURRENCY, currency)
             .putBundleList(FirebaseAnalytics.Param.ITEMS, getProductBundles(commerceEvent))
+
+        return pickyBundle
     }
 
     private fun getProductBundles(commerceEvent: CommerceEvent): Array<Bundle> {


### PR DESCRIPTION
## Summary
- Commerce event custom attributes are now being sent to GA4..

## Testing Plan
- All test passed, end to end test made on the Firebase dashboard.

## Reference Issue
- Closes https://go.mparticle.com/work/SQDSDKS-4668
