### PR TITLE
fix: Always Capture App Instance Id

### DIFF
--- a/src/main/kotlin/com/mparticle/kits/GoogleAnalyticsFirebaseGA4Kit.kt
+++ b/src/main/kotlin/com/mparticle/kits/GoogleAnalyticsFirebaseGA4Kit.kt
@@ -31,9 +31,7 @@ class GoogleAnalyticsFirebaseGA4Kit : KitIntegration(), KitIntegration.EventList
         context: Context
     ): List<ReportingMessage>? {
         Logger.info("$name Kit relies on a functioning instance of Firebase Analytics. If your Firebase Analytics instance is not configured properly, this Kit will not work")
-        if (forwardRequestsServerSide()) {
-            updateInstanceIDIntegration()
-        }
+        updateInstanceIDIntegration()
         return null
     }
 

--- a/src/test/kotlin/com/mparticle/kits/GoogleAnalyticsFirebaseGA4KitTest.kt
+++ b/src/test/kotlin/com/mparticle/kits/GoogleAnalyticsFirebaseGA4KitTest.kt
@@ -56,9 +56,7 @@ class GoogleAnalyticsFirebaseGA4KitTest {
         kitInstance.kitManager = kitManager
         kitInstance.configuration =
             KitConfiguration.createKitConfiguration(JSONObject().put("id", "-1"))
-        kitInstance.onKitCreate(HashMap(), Mockito.mock(Context::class.java))
         firebaseSdk = FirebaseAnalytics.getInstance(null)!!
-
     }
 
     /**


### PR DESCRIPTION
## Instructions
## Summary
 - Update the kit to always gather profile information no matter if we are forwarding server side or not

 ## Testing Plan
 - Tested end to end to confirm functionality

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-5075
