### PR TITLE
feat: 5277 ga4 event cleansing invalid characters

### DIFF
--- a/src/main/kotlin/com/mparticle/kits/GoogleAnalyticsFirebaseGA4Kit.kt
+++ b/src/main/kotlin/com/mparticle/kits/GoogleAnalyticsFirebaseGA4Kit.kt
@@ -582,14 +582,16 @@ class GoogleAnalyticsFirebaseGA4Kit : KitIntegration(), KitIntegration.EventList
 
         var name = nameIn ?: return invalidGA4Key
 
-        name = name.replace("[^a-zA-Z0-9_]".toRegex(), "_")
-        for (forbiddenPrefix in forbiddenPrefixes) {
-            if (name.startsWith(forbiddenPrefix)) {
-                name = name.replaceFirst(forbiddenPrefix.toRegex(), "")
+        if (event) {
+            name = name.replace("[^a-zA-Z0-9_]".toRegex(), "_")
+            for (forbiddenPrefix in forbiddenPrefixes) {
+                if (name.startsWith(forbiddenPrefix)) {
+                    name = name.replaceFirst(forbiddenPrefix.toRegex(), "")
+                }
             }
-        }
-        while (name.isNotEmpty() && !Character.isLetter(name.toCharArray()[0])) {
-            name = name.substring(1)
+            while (name.isNotEmpty() && !Character.isLetter(name.toCharArray()[0])) {
+                name = name.substring(1)
+            }
         }
         if (event) {
             if (name.length > eventMaxLength) {

--- a/src/main/kotlin/com/mparticle/kits/GoogleAnalyticsFirebaseGA4Kit.kt
+++ b/src/main/kotlin/com/mparticle/kits/GoogleAnalyticsFirebaseGA4Kit.kt
@@ -580,10 +580,9 @@ class GoogleAnalyticsFirebaseGA4Kit : KitIntegration(), KitIntegration.EventList
 
     fun standardizeName(nameIn: String?, event: Boolean): String? {
 
-        var name = nameIn ?: return null
+        var name = nameIn ?: return invalidGA4Key
 
-        name = name.replace("[^a-zA-Z0-9_\\s]".toRegex(), " ")
-        name = name.replace("[\\s]+".toRegex(), "_")
+        name = name.replace("[^a-zA-Z0-9_]".toRegex(), "_")
         for (forbiddenPrefix in forbiddenPrefixes) {
             if (name.startsWith(forbiddenPrefix)) {
                 name = name.replaceFirst(forbiddenPrefix.toRegex(), "")
@@ -601,7 +600,11 @@ class GoogleAnalyticsFirebaseGA4Kit : KitIntegration(), KitIntegration.EventList
                 name = name.substring(0, userAttributeMaxLength)
             }
         }
-        return name
+        if (name.isNotEmpty()) {
+            return name
+        } else {
+            return invalidGA4Key
+        }
     }
 
     class PickyBundle {
@@ -671,6 +674,7 @@ class GoogleAnalyticsFirebaseGA4Kit : KitIntegration(), KitIntegration.EventList
         private const val userAttributeMaxLength = 24
         private const val eventValMaxLength = 100
         private const val userAttributeValMaxLength = 36
+        private const val invalidGA4Key = "invalid_ga4_key"
         private const val KIT_NAME = "GA4 for Firebase"
         private const val CURRENCY_FIELD_NOT_SET =
             "Currency field required by Firebase was not set, defaulting to 'USD'"

--- a/src/test/kotlin/com/mparticle/kits/GoogleAnalyticsFirebaseGA4KitTest.kt
+++ b/src/test/kotlin/com/mparticle/kits/GoogleAnalyticsFirebaseGA4KitTest.kt
@@ -212,7 +212,7 @@ class GoogleAnalyticsFirebaseGA4KitTest {
     fun testNameStandardization() {
         val badPrefixes = arrayOf("firebase_event_name", "google_event_name", "ga_event_name")
         for (badPrefix in badPrefixes) {
-            val clean = kitInstance.standardizeName(badPrefix, random.nextBoolean())
+            val clean = kitInstance.standardizeName(badPrefix, true)
             TestCase.assertEquals("event_name", clean)
         }
         val emptySpace1 = "event name"
@@ -221,20 +221,41 @@ class GoogleAnalyticsFirebaseGA4KitTest {
         val emptySpace4 = "event - name "
         TestCase.assertEquals(
             "event_name",
-            kitInstance.standardizeName(emptySpace1, random.nextBoolean())
+            kitInstance.standardizeName(emptySpace1, true)
         )
         TestCase.assertEquals(
             "event_name_",
-            kitInstance.standardizeName(emptySpace2, random.nextBoolean())
+            kitInstance.standardizeName(emptySpace2, true)
         )
         TestCase.assertEquals(
             "event__name_",
-            kitInstance.standardizeName(emptySpace3, random.nextBoolean())
+            kitInstance.standardizeName(emptySpace3, true)
         )
         TestCase.assertEquals(
             "event___name_",
-            kitInstance.standardizeName(emptySpace4, random.nextBoolean())
+            kitInstance.standardizeName(emptySpace4, true)
         )
+        TestCase.assertEquals(
+            "event_name ",
+            kitInstance.standardizeName(emptySpace2, false)
+        )
+        TestCase.assertEquals(
+            "event  name ",
+            kitInstance.standardizeName(emptySpace3, false)
+        )
+        TestCase.assertEquals(
+            "event - name ",
+            kitInstance.standardizeName(emptySpace4, false)
+        )
+        TestCase.assertEquals(
+            "!event - name !",
+            kitInstance.standardizeName("!event - name !", false)
+        )
+        TestCase.assertEquals(
+            "!@#\$%^&*()_+=[]{}|'\"?>",
+            kitInstance.standardizeName("!@#\$%^&*()_+=[]{}|'\"?>", false)
+        )
+
         val badStarts = arrayOf(
             "!@#$%^&*()_+=[]{}|'\"?><:;event_name",
             "_event_name",
@@ -242,7 +263,7 @@ class GoogleAnalyticsFirebaseGA4KitTest {
             "_event_name"
         )
         for (badStart in badStarts) {
-            val clean = kitInstance.standardizeName(badStart, random.nextBoolean())
+            val clean = kitInstance.standardizeName(badStart, true)
             TestCase.assertEquals("event_name", clean)
         }
         val tooLong =
@@ -267,7 +288,7 @@ class GoogleAnalyticsFirebaseGA4KitTest {
             ""
         )
         for (emptyString in emptyStrings) {
-            val empty = kitInstance.standardizeName(emptyString, random.nextBoolean())
+            val empty = kitInstance.standardizeName(emptyString, true)
             TestCase.assertEquals("invalid_ga4_key", empty)
         }
     }

--- a/src/test/kotlin/com/mparticle/kits/GoogleAnalyticsFirebaseGA4KitTest.kt
+++ b/src/test/kotlin/com/mparticle/kits/GoogleAnalyticsFirebaseGA4KitTest.kt
@@ -228,11 +228,11 @@ class GoogleAnalyticsFirebaseGA4KitTest {
             kitInstance.standardizeName(emptySpace2, random.nextBoolean())
         )
         TestCase.assertEquals(
-            "event_name_",
+            "event__name_",
             kitInstance.standardizeName(emptySpace3, random.nextBoolean())
         )
         TestCase.assertEquals(
-            "event_name_",
+            "event___name_",
             kitInstance.standardizeName(emptySpace4, random.nextBoolean())
         )
         val badStarts = arrayOf(
@@ -260,6 +260,16 @@ class GoogleAnalyticsFirebaseGA4KitTest {
         TestCase.assertEquals(36, sanitized.length)
         TestCase.assertTrue(tooLong.startsWith(sanitized))
 
+        val emptyStrings = arrayOf(
+            "!@#$%^&*()_+=[]{}|'\"?><:;",
+            "_1234567890",
+            " ",
+            ""
+        )
+        for (emptyString in emptyStrings) {
+            val empty = kitInstance.standardizeName(emptyString, random.nextBoolean())
+            TestCase.assertEquals("invalid_ga4_key", empty)
+        }
     }
 
     @Test


### PR DESCRIPTION
## Summary
 - GA places multiple limitations on keys/values related to valid characters. We need to consistently replace & remove invalid characters before forwarding data.
 
1. Implement data cleansing as the last operation before forwarding data to GA
2. Event names must be 40 characters or fewer, may only contain alpha-numeric characters and underscores, and must start with an alphabetic character.
3. Parameter names (including item parameters) must be 40 characters or fewer, may only contain alpha-numeric characters and underscores, and must start with an alphabetic character.
4. Parameter values (including item parameter values) must be 100 characters or fewer.
5. User property names must be 24 characters or fewer.
6. User property values must be 36 characters or fewer.
7. Update tech spec validation table on confluence

 ## Testing Plan
 - Tested through unit tests and locally by manually confirming the outputs based on test values

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-5277
