### PR TITLE
feat: Add Customer Configurable Standardization

### DIFF
--- a/src/main/kotlin/com/mparticle/kits/GoogleAnalyticsFirebaseGA4Kit.kt
+++ b/src/main/kotlin/com/mparticle/kits/GoogleAnalyticsFirebaseGA4Kit.kt
@@ -23,6 +23,8 @@ import java.math.BigDecimal
 
 class GoogleAnalyticsFirebaseGA4Kit : KitIntegration(), KitIntegration.EventListener,
     IdentityListener, CommerceListener, KitIntegration.UserAttributeListener {
+    private var clientStandardizationCallback: MPClientStandardization? = null
+
     override fun getName(): String = KIT_NAME
 
     @Throws(IllegalArgumentException::class)
@@ -33,6 +35,10 @@ class GoogleAnalyticsFirebaseGA4Kit : KitIntegration(), KitIntegration.EventList
         Logger.info("$name Kit relies on a functioning instance of Firebase Analytics. If your Firebase Analytics instance is not configured properly, this Kit will not work")
         updateInstanceIDIntegration()
         return null
+    }
+
+    open fun setClientStandardizationCallback(standardizationCallback: MPClientStandardization) {
+        clientStandardizationCallback = standardizationCallback
     }
 
     override fun setOptOut(b: Boolean): List<ReportingMessage> = emptyList()
@@ -589,6 +595,10 @@ class GoogleAnalyticsFirebaseGA4Kit : KitIntegration(), KitIntegration.EventList
 
         var name = nameIn ?: return invalidGA4Key
 
+        if (clientStandardizationCallback != null) {
+            name = clientStandardizationCallback!!.nameStandardization(name)
+        }
+
         if (event) {
             name = name.replace("[^a-zA-Z0-9_]".toRegex(), "_")
             for (forbiddenPrefix in forbiddenPrefixes) {
@@ -692,4 +702,7 @@ class GoogleAnalyticsFirebaseGA4Kit : KitIntegration(), KitIntegration.EventList
         private const val USD = "USD"
     }
 
+    public interface MPClientStandardization {
+        fun nameStandardization(name: String): String;
+    }
 }

--- a/src/test/kotlin/com/mparticle/kits/GoogleAnalyticsFirebaseGA4KitTest.kt
+++ b/src/test/kotlin/com/mparticle/kits/GoogleAnalyticsFirebaseGA4KitTest.kt
@@ -312,6 +312,24 @@ class GoogleAnalyticsFirebaseGA4KitTest {
             val empty = kitInstance.standardizeName(emptyString, true)
             TestCase.assertEquals("invalid_ga4_key", empty)
         }
+
+        var callback = object : GoogleAnalyticsFirebaseGA4Kit.MPClientStandardization {
+            override fun nameStandardization(name: String): String { return "test" }
+        }
+
+        kitInstance.setClientStandardizationCallback(callback)
+
+        val clientTestStrings = arrayOf(
+            "this",
+            "is",
+            "not",
+            "a",
+            "test"
+        )
+        for (clientString in clientTestStrings) {
+            val client = kitInstance.standardizeName(clientString, true)
+            TestCase.assertEquals("test", client)
+        }
     }
 
     @Test


### PR DESCRIPTION
## Summary
 Implement the following scheme to support customer-configurable cleansing:

provide a client-side callback method on the ga4 kit for event & parameters names

callback is executed prior to our standard data cleansing

customer receives a single event/parameter name string on each callback that can be altered as required

our standard data cleansing method executes directly after the customer callback and cleanses anything that was missed.

 ## Testing Plan
 Tested locally and through unit tests

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-5464
