### PR TITLE
fix: Implement getInstance for Kit

### DIFF
--- a/src/main/kotlin/com/mparticle/kits/GoogleAnalyticsFirebaseGA4Kit.kt
+++ b/src/main/kotlin/com/mparticle/kits/GoogleAnalyticsFirebaseGA4Kit.kt
@@ -27,6 +27,10 @@ class GoogleAnalyticsFirebaseGA4Kit : KitIntegration(), KitIntegration.EventList
 
     override fun getName(): String = KIT_NAME
 
+    override fun getInstance(): GoogleAnalyticsFirebaseGA4Kit? {
+        return this
+    }
+
     @Throws(IllegalArgumentException::class)
     public override fun onKitCreate(
         map: Map<String, String>,


### PR DESCRIPTION
## Summary
 - Added the getInstance method

 ## Testing Plan
 - Tested locally

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/REPLACEME
