### PR TITLE
fix: Make Standardization Callback Setter Static

### DIFF
--- a/src/main/kotlin/com/mparticle/kits/GoogleAnalyticsFirebaseGA4Kit.kt
+++ b/src/main/kotlin/com/mparticle/kits/GoogleAnalyticsFirebaseGA4Kit.kt
@@ -23,8 +23,6 @@ import java.math.BigDecimal
 
 class GoogleAnalyticsFirebaseGA4Kit : KitIntegration(), KitIntegration.EventListener,
     IdentityListener, CommerceListener, KitIntegration.UserAttributeListener {
-    private var clientStandardizationCallback: MPClientStandardization? = null
-
     override fun getName(): String = KIT_NAME
 
     @Throws(IllegalArgumentException::class)
@@ -35,10 +33,6 @@ class GoogleAnalyticsFirebaseGA4Kit : KitIntegration(), KitIntegration.EventList
         Logger.info("$name Kit relies on a functioning instance of Firebase Analytics. If your Firebase Analytics instance is not configured properly, this Kit will not work")
         updateInstanceIDIntegration()
         return null
-    }
-
-    open fun setClientStandardizationCallback(standardizationCallback: MPClientStandardization) {
-        clientStandardizationCallback = standardizationCallback
     }
 
     override fun setOptOut(b: Boolean): List<ReportingMessage> = emptyList()
@@ -663,6 +657,13 @@ class GoogleAnalyticsFirebaseGA4Kit : KitIntegration(), KitIntegration.EventList
     }
 
     companion object {
+        private var clientStandardizationCallback: MPClientStandardization? = null
+
+        @JvmStatic
+        fun setClientStandardizationCallback(standardizationCallback: MPClientStandardization?) {
+            clientStandardizationCallback = standardizationCallback
+        }
+
         const val SHOULD_HASH_USER_ID = "hashUserId"
         const val FORWARD_REQUESTS_SERVER_SIDE = "forwardWebRequestsServerSide"
         const val EXTERNAL_USER_IDENTITY_TYPE = "externalUserIdentityType"

--- a/src/test/kotlin/com/mparticle/kits/GoogleAnalyticsFirebaseGA4KitTest.kt
+++ b/src/test/kotlin/com/mparticle/kits/GoogleAnalyticsFirebaseGA4KitTest.kt
@@ -330,6 +330,15 @@ class GoogleAnalyticsFirebaseGA4KitTest {
             val client = kitInstance.standardizeName(clientString, true)
             TestCase.assertEquals("test", client)
         }
+
+        var callbackCheck = object : GoogleAnalyticsFirebaseGA4Kit.MPClientStandardization {
+            override fun nameStandardization(name: String): String { return name }
+        }
+
+        GoogleAnalyticsFirebaseGA4Kit.setClientStandardizationCallback(callbackCheck)
+
+        val client = kitInstance.standardizeName("clientString", true)
+        TestCase.assertEquals("clientString", client)
     }
 
     @Test

--- a/src/test/kotlin/com/mparticle/kits/GoogleAnalyticsFirebaseGA4KitTest.kt
+++ b/src/test/kotlin/com/mparticle/kits/GoogleAnalyticsFirebaseGA4KitTest.kt
@@ -3,7 +3,6 @@ package com.mparticle.kits
 import android.app.Activity
 import android.content.Context
 import android.net.Uri
-import android.os.Bundle
 import com.google.firebase.analytics.FirebaseAnalytics
 import com.mparticle.MPEvent
 import com.mparticle.MParticle
@@ -58,6 +57,7 @@ class GoogleAnalyticsFirebaseGA4KitTest {
         kitInstance.configuration =
             KitConfiguration.createKitConfiguration(JSONObject().put("id", "-1"))
         firebaseSdk = FirebaseAnalytics.getInstance(null)!!
+        GoogleAnalyticsFirebaseGA4Kit.setClientStandardizationCallback(null)
     }
 
     /**
@@ -317,7 +317,7 @@ class GoogleAnalyticsFirebaseGA4KitTest {
             override fun nameStandardization(name: String): String { return "test" }
         }
 
-        kitInstance.setClientStandardizationCallback(callback)
+        GoogleAnalyticsFirebaseGA4Kit.setClientStandardizationCallback(callback)
 
         val clientTestStrings = arrayOf(
             "this",


### PR DESCRIPTION
## Summary
 - Make Standardization Callback Setter Static for easier usage

 ## Testing Plan
 - Tested locally and through unit tests

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-5464
