### PR TITLE
fix: Update allowable character limits and number of attributes for GA360

### DIFF
--- a/src/main/kotlin/com/mparticle/kits/GoogleAnalyticsFirebaseGA4Kit.kt
+++ b/src/main/kotlin/com/mparticle/kits/GoogleAnalyticsFirebaseGA4Kit.kt
@@ -688,8 +688,10 @@ class GoogleAnalyticsFirebaseGA4Kit : KitIntegration(), KitIntegration.EventList
         private val forbiddenPrefixes = arrayOf("google_", "firebase_", "ga_")
         private const val eventMaxLength = 40
         private const val userAttributeMaxLength = 24
+        // Following limits are based off Google Analytics 360 limits, docs here "https://support.google.com/analytics/answer/11202874?sjid=14644072134282618832-NA#limits"
         private const val eventValMaxLength = 500
         private const val userAttributeValMaxLength = 36
+        // Following limits are based off Google Analytics 360 limits, docs here "https://support.google.com/analytics/answer/11202874?sjid=14644072134282618832-NA#limits"
         private const val eventMaxParameterProperty = 100
         private const val itemMaxParameter = 25
         private const val invalidGA4Key = "invalid_ga4_key"

--- a/src/main/kotlin/com/mparticle/kits/GoogleAnalyticsFirebaseGA4Kit.kt
+++ b/src/main/kotlin/com/mparticle/kits/GoogleAnalyticsFirebaseGA4Kit.kt
@@ -691,7 +691,6 @@ class GoogleAnalyticsFirebaseGA4Kit : KitIntegration(), KitIntegration.EventList
         // Following limits are based off Google Analytics 360 limits, docs here "https://support.google.com/analytics/answer/11202874?sjid=14644072134282618832-NA#limits"
         private const val eventValMaxLength = 500
         private const val userAttributeValMaxLength = 36
-        // Following limits are based off Google Analytics 360 limits, docs here "https://support.google.com/analytics/answer/11202874?sjid=14644072134282618832-NA#limits"
         private const val eventMaxParameterProperty = 100
         private const val itemMaxParameter = 25
         private const val invalidGA4Key = "invalid_ga4_key"

--- a/src/main/kotlin/com/mparticle/kits/GoogleAnalyticsFirebaseGA4Kit.kt
+++ b/src/main/kotlin/com/mparticle/kits/GoogleAnalyticsFirebaseGA4Kit.kt
@@ -688,10 +688,10 @@ class GoogleAnalyticsFirebaseGA4Kit : KitIntegration(), KitIntegration.EventList
         private val forbiddenPrefixes = arrayOf("google_", "firebase_", "ga_")
         private const val eventMaxLength = 40
         private const val userAttributeMaxLength = 24
-        private const val eventValMaxLength = 100
+        private const val eventValMaxLength = 500
         private const val userAttributeValMaxLength = 36
-        private const val eventMaxParameterProperty = 25
-        private const val itemMaxParameter = 10
+        private const val eventMaxParameterProperty = 100
+        private const val itemMaxParameter = 25
         private const val invalidGA4Key = "invalid_ga4_key"
         private const val KIT_NAME = "GA4 for Firebase"
         private const val CURRENCY_FIELD_NOT_SET =

--- a/src/test/kotlin/com/mparticle/kits/GoogleAnalyticsFirebaseGA4KitTest.kt
+++ b/src/test/kotlin/com/mparticle/kits/GoogleAnalyticsFirebaseGA4KitTest.kt
@@ -290,7 +290,7 @@ class GoogleAnalyticsFirebaseGA4KitTest {
         TestCase.assertTrue(justFine.startsWith(sanitized))
 
         val tooLong =
-            "abcdefghijklmnopqrstuvwxyz1234567890abcdefghijklmnopqrstuvwxyz1234567890abcdefghijklmnopqrstuvwxyz1234567890abcdefghijklmnopqrstuvwxyz1234567890"
+            "abcdefghijklmnopqrstuvwxyz1234567890abcdefghijklmnopqrstuvwxyz1234567890abcdefghijklmnopqrstuvwxyz1234567890abcdefghijklmnopqrstuvwxyz1234567890abcdefghijklmnopqrstuvwxyz1234567890abcdefghijklmnopqrstuvwxyz1234567890abcdefghijklmnopqrstuvwxyz1234567890abcdefghijklmnopqrstuvwxyz1234567890abcdefghijklmnopqrstuvwxyz1234567890abcdefghijklmnopqrstuvwxyz1234567890abcdefghijklmnopqrstuvwxyz1234567890abcdefghijklmnopqrstuvwxyz1234567890abcdefghijklmnopqrstuvwxyz1234567890abcdefghijklmnopqrstuvwxyz1234567890abcdefghijklmnopqrstuvwxyz1234567890abcdefghijklmnopqrstuvwxyz1234567890"
         sanitized = kitInstance.standardizeName(tooLong, true).toString()
         TestCase.assertEquals(40, sanitized.length)
         TestCase.assertTrue(tooLong.startsWith(sanitized))
@@ -298,7 +298,7 @@ class GoogleAnalyticsFirebaseGA4KitTest {
         TestCase.assertEquals(24, sanitized.length)
         TestCase.assertTrue(tooLong.startsWith(sanitized))
         sanitized = kitInstance.standardizeValue(tooLong, true)
-        TestCase.assertEquals(100, sanitized.length)
+        TestCase.assertEquals(500, sanitized.length)
         TestCase.assertTrue(tooLong.startsWith(sanitized))
         sanitized = kitInstance.standardizeValue(tooLong, false)
         TestCase.assertEquals(36, sanitized.length)


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
 - Change GA4 Limits to Enterprise Plan Standard
 
 ## Testing Plan
 No, we do not have access to a GA360 account, PR is just a change in the value of max attributes allowed.
 - {explain how this has been tested, and what, if any, additional testing should be done}

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-6134
