### PR TITLE
feat: Add product brand to e-commerce event products

### DIFF
--- a/src/main/kotlin/com/mparticle/kits/GoogleAnalyticsFirebaseGA4Kit.kt
+++ b/src/main/kotlin/com/mparticle/kits/GoogleAnalyticsFirebaseGA4Kit.kt
@@ -499,6 +499,7 @@ class GoogleAnalyticsFirebaseGA4Kit : KitIntegration(), KitIntegration.EventList
             put(FirebaseAnalytics.Param.ITEM_NAME, product.name)
             put(FirebaseAnalytics.Param.PRICE, product.unitPrice)
             product.category?.let { put(FirebaseAnalytics.Param.ITEM_CATEGORY, it) }
+            product.brand?.let { put(FirebaseAnalytics.Param.ITEM_BRAND, it) }
         }
     }
 


### PR DESCRIPTION
## Summary
We are adding the product brand to the ecommerce event logging to match the feature that web already has.

 ## Testing Plan
 - [X] Was this tested locally? If not, explain why.

Manually tested via the Firebase debugger.
Before change:
Purchase

<img width="467" alt="image" src="https://github.com/mparticle-integrations/mparticle-android-integration-google-analytics-firebase-ga4/assets/136605018/bc4344b8-1c3f-4055-a605-30dcc99db1b3">


Impression

<img width="492" alt="image" src="https://github.com/mparticle-integrations/mparticle-android-integration-google-analytics-firebase-ga4/assets/136605018/f2b61592-ce33-4c3b-b3f5-bb11c504e743">

After change:

Purchase

<img width="587" alt="image" src="https://github.com/mparticle-integrations/mparticle-android-integration-google-analytics-firebase-ga4/assets/136605018/f1520602-f826-422e-ab1e-745fb3131db0">

Impression

<img width="545" alt="image" src="https://github.com/mparticle-integrations/mparticle-android-integration-google-analytics-firebase-ga4/assets/136605018/22b81ab2-0d55-453e-8d0f-c8b8dff5dd35">


