### PR TITLE
fix: forward Impressions and Promotions custom attributes

### DIFF
--- a/src/main/kotlin/com/mparticle/kits/GoogleAnalyticsFirebaseGA4Kit.kt
+++ b/src/main/kotlin/com/mparticle/kits/GoogleAnalyticsFirebaseGA4Kit.kt
@@ -364,9 +364,7 @@ class GoogleAnalyticsFirebaseGA4Kit : KitIntegration(), KitIntegration.EventList
         customAttributesStrings: Map<String, String>?
     ): PickyBundle {
         var pickyBundle = PickyBundle()
-        if (promotion == null) {
-            return pickyBundle
-        } else {
+        if (promotion != null) {
             pickyBundle
                 .putString(FirebaseAnalytics.Param.PROMOTION_ID, promotion.id)
                 .putString(
@@ -391,9 +389,8 @@ class GoogleAnalyticsFirebaseGA4Kit : KitIntegration(), KitIntegration.EventList
                     }
                 }
             }
-
-            return pickyBundle
         }
+        return pickyBundle
     }
 
     private fun getImpressionCommerceEventBundle(


### PR DESCRIPTION
 ## Summary
 - A customer reported that we don't forward custom attributes for impression and promotion events downstream to GA4 when using the kit, after further investigation and being to reproduce I was able to find the code responsible for this behavior and this PR is the fix.

 ## Testing Plan
 - [Y] Was this tested locally? If not, explain why.
 - kit was imported locally to a sample Android app and with the added code, I was able to confirm to see attributes to arrive for both impression and promotion events in the GA4 Firebase dashboard.

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://mparticle-eng.atlassian.net/browse/PRODRDMP-7120
