### PR TITLE
feat: use logEvent instead of deprecated setCurrentScreen and forw…

### DIFF
--- a/src/main/kotlin/com/mparticle/kits/GoogleAnalyticsFirebaseGA4Kit.kt
+++ b/src/main/kotlin/com/mparticle/kits/GoogleAnalyticsFirebaseGA4Kit.kt
@@ -63,8 +63,8 @@ class GoogleAnalyticsFirebaseGA4Kit : KitIntegration(), KitIntegration.EventList
     }
 
     override fun logScreen(
-            screenName: String,
-            screenAttributes: Map<String, String>?
+        screenName: String,
+        screenAttributes: Map<String, String>?
     ): List<ReportingMessage> {
         if (forwardRequestsServerSide()) {
             return emptyList()

--- a/src/main/kotlin/com/mparticle/kits/GoogleAnalyticsFirebaseGA4Kit.kt
+++ b/src/main/kotlin/com/mparticle/kits/GoogleAnalyticsFirebaseGA4Kit.kt
@@ -62,14 +62,19 @@ class GoogleAnalyticsFirebaseGA4Kit : KitIntegration(), KitIntegration.EventList
         return listOf(ReportingMessage.fromEvent(this, mpEvent))
     }
 
-    override fun logScreen(s: String, map: Map<String, String>?): List<ReportingMessage> {
+    override fun logScreen(
+            screenName: String,
+            screenAttributes: Map<String, String>?
+    ): List<ReportingMessage> {
         if (forwardRequestsServerSide()) {
             return emptyList()
         }
+        val bundle = toBundle(screenAttributes)
+        bundle.putString(FirebaseAnalytics.Param.SCREEN_NAME, standardizeName(screenName, true))
         val activity = currentActivity.get()
         if (activity != null) {
             FirebaseAnalytics.getInstance(context)
-                .setCurrentScreen(activity, standardizeName(s, true), null)
+                .logEvent(FirebaseAnalytics.Event.SCREEN_VIEW, bundle)
             return listOf(
                 ReportingMessage(
                     this,

--- a/src/test/kotlin/com/mparticle/kits/GoogleAnalyticsFirebaseGA4KitTest.kt
+++ b/src/test/kotlin/com/mparticle/kits/GoogleAnalyticsFirebaseGA4KitTest.kt
@@ -1104,18 +1104,18 @@ class GoogleAnalyticsFirebaseGA4KitTest {
         val firebaseScreenViewEvent = firebaseSdk.loggedEvents[0]
         // even though we are passing one attribute, it should contain two including the screen_name
         TestCase.assertEquals(
-                2,
-                firebaseScreenViewEvent.value.size()
+            2,
+            firebaseScreenViewEvent.value.size()
         )
         // make sure the even name is correct with Firebase's constant SCREEN_NAME value
         TestCase.assertEquals(
-                "screen_view",
-                firebaseScreenViewEvent.key
+            "screen_view",
+            firebaseScreenViewEvent.key
         )
         // make sure that the Params include the screenName value
         TestCase.assertEquals(
-                "testScreenName",
-                firebaseScreenViewEvent.value.getString("screen_name")
+            "testScreenName",
+            firebaseScreenViewEvent.value.getString("screen_name")
         )
     }
 

--- a/src/test/kotlin/com/mparticle/kits/GoogleAnalyticsFirebaseGA4KitTest.kt
+++ b/src/test/kotlin/com/mparticle/kits/GoogleAnalyticsFirebaseGA4KitTest.kt
@@ -1089,9 +1089,33 @@ class GoogleAnalyticsFirebaseGA4KitTest {
     @Test
     fun testScreenNameSanitized() {
         kitInstance.logScreen("Some long Screen name", null)
+        val firebaseScreenViewEvent = firebaseSdk.loggedEvents[0]
         TestCase.assertEquals(
             "Some_long_Screen_name",
-            FirebaseAnalytics.getInstance(null)?.currentScreenName
+            firebaseScreenViewEvent.value.getString("screen_name")
+        )
+    }
+
+    @Test
+    fun testScreenNameAttributes() {
+        val attributes = hashMapOf<String, String>()
+        attributes["testAttributeKey"] = "testAttributeValue"
+        kitInstance.logScreen("testScreenName", attributes)
+        val firebaseScreenViewEvent = firebaseSdk.loggedEvents[0]
+        // even though we are passing one attribute, it should contain two including the screen_name
+        TestCase.assertEquals(
+                2,
+                firebaseScreenViewEvent.value.size()
+        )
+        // make sure the even name is correct with Firebase's constant SCREEN_NAME value
+        TestCase.assertEquals(
+                "screen_view",
+                firebaseScreenViewEvent.key
+        )
+        // make sure that the Params include the screenName value
+        TestCase.assertEquals(
+                "testScreenName",
+                firebaseScreenViewEvent.value.getString("screen_name")
         )
     }
 


### PR DESCRIPTION
…ard screenView attributes

 ## Summary
 - we are still using deprecated setCurrentScreen which [Google](https://firebase.google.com/docs/reference/android/com/google/firebase/analytics/FirebaseAnalytics#setCurrentScreen(android.app.Activity,java.lang.String,java.lang.String)) now recommend using logEvent instead as mentioned here, also with using logEvent we can now send the screen view event's custom attributes as part of the Params

 ## Testing Plan
 - [Y] Was this tested locally? If not, explain why.
 - E2E tested and unit test is also included

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://mparticle-eng.atlassian.net/browse/SQDSDKS-6968
