### PR TITLE
feat: forward product custom attributes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,5 +50,5 @@ dependencies {
     testImplementation files('libs/test-utils.aar')
     testImplementation 'com.google.android.gms:play-services-measurement-api:21.5.1'
 
-    compileOnly 'com.google.firebase:firebase-analytics:[21.5.1,)'
+    compileOnly 'com.google.firebase:firebase-analytics:21.5.1'
 }

--- a/src/main/kotlin/com/mparticle/kits/GoogleAnalyticsFirebaseGA4Kit.kt
+++ b/src/main/kotlin/com/mparticle/kits/GoogleAnalyticsFirebaseGA4Kit.kt
@@ -531,6 +531,11 @@ class GoogleAnalyticsFirebaseGA4Kit : KitIntegration(), KitIntegration.EventList
             put(FirebaseAnalytics.Param.PRICE, product.unitPrice)
             product.category?.let { put(FirebaseAnalytics.Param.ITEM_CATEGORY, it) }
             product.brand?.let { put(FirebaseAnalytics.Param.ITEM_BRAND, it) }
+            product.customAttributes?.let {
+                for ((key, value) in it) {
+                    put(key, value)
+                }
+            }
         }
     }
 


### PR DESCRIPTION
 ## Summary
 - A customer raised an issue that we don't forward product custom attributes to GA4/Firebase, after further investigation, I was able to verify that Google accept mapped custom attributes as mentioned [here](https://firebase.google.com/docs/analytics/measure-ecommerce#objective-c_13)
 - Another point to note, the change in the build.gradle file was recommended by @Mansi-mParticle after having issues building and testing the kit in both my sample app and the kit itself

 ## Testing Plan
 - [Y] Was this tested locally? If not, explain why.
 - Unit tested and E2E tested

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://mparticle-eng.atlassian.net/browse/SQDSDKS-7037
