### PR TITLE
feat: Update Firebase Analytics to v22

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ apply plugin: 'kotlin-android'
 
 android {
     defaultConfig {
-        minSdkVersion 16
+        minSdkVersion 21
     }
     testOptions {
          unitTests.all {
@@ -48,7 +48,7 @@ android {
 dependencies {
     testImplementation files('libs/java-json.jar')
     testImplementation files('libs/test-utils.aar')
-    testImplementation 'com.google.android.gms:play-services-measurement-api:21.5.1'
+    testImplementation 'com.google.android.gms:play-services-measurement-api:22.1.0'
 
-    compileOnly 'com.google.firebase:firebase-analytics:21.5.1'
+    compileOnly 'com.google.firebase:firebase-analytics:22.1.0'
 }


### PR DESCRIPTION
 ## Summary
 - We are currently on Firebase v21 and Google released Firebase v22 as mentioned [here](https://firebase.google.com/support/release-notes/android#analytics_v22-0-0), this PR is to update the Firebase version to v22

 ## Testing Plan
 - [X] Was this tested locally? If not, explain why.
 - E2E and Unit tested

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-6954