### PR TITLE
feat: Map product position to Firebase item index

### DIFF
--- a/src/main/kotlin/com/mparticle/kits/GoogleAnalyticsFirebaseGA4Kit.kt
+++ b/src/main/kotlin/com/mparticle/kits/GoogleAnalyticsFirebaseGA4Kit.kt
@@ -536,6 +536,7 @@ class GoogleAnalyticsFirebaseGA4Kit : KitIntegration(), KitIntegration.EventList
             put(FirebaseAnalytics.Param.PRICE, product.unitPrice)
             product.category?.let { put(FirebaseAnalytics.Param.ITEM_CATEGORY, it) }
             product.brand?.let { put(FirebaseAnalytics.Param.ITEM_BRAND, it) }
+            product.position?.let { put(FirebaseAnalytics.Param.INDEX, it) }
             product.customAttributes?.let {
                 for ((key, value) in it) {
                     put(key, value)

--- a/src/test/kotlin/com/mparticle/kits/GoogleAnalyticsFirebaseGA4KitTest.kt
+++ b/src/test/kotlin/com/mparticle/kits/GoogleAnalyticsFirebaseGA4KitTest.kt
@@ -981,6 +981,7 @@ class GoogleAnalyticsFirebaseGA4KitTest {
             .quantity(1.0)
             .brand("LV")
             .category("vegetable")
+            .position(4)
             .customAttributes(attributes)
             .build()
 
@@ -993,10 +994,10 @@ class GoogleAnalyticsFirebaseGA4KitTest {
         val firebaseProducts = firebaseImpressionEvent.value.get("items") as? Array<Bundle>
         val firebaseProduct = firebaseProducts?.get(0)
 
-        // test the count of parameters for product, even though we only pass 2 custom attributes
-        // we expect the total to be 8 to include name, price, quantity, sku, brand ans category
+        // test the count of parameters for product, even though we only pass 2 custom attributes we
+        // expect the total to be 9 to include name, price, quantity, sku, brand, category and position
         TestCase.assertEquals(
-            8,
+            9,
             firebaseProduct?.size()
         )
     }


### PR DESCRIPTION
 ## Summary
 - Firebase/GA4 have item index as part of the item parameters for eCommerce events (docs [here](https://developers.google.com/analytics/devguides/collection/ga4/reference/events?client_type=gtag#view_item_list_item)) and a customer requested our kits to support this parameter since we already have product positions that can be mapped to

 ## Testing Plan
 - [X] Was this tested locally? If not, explain why.
 - E2E and unit tested

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-7177
